### PR TITLE
Change column name 'login-name' -> 'login_name'

### DIFF
--- a/simple-todo-app/resources/changelog.edn
+++ b/simple-todo-app/resources/changelog.edn
@@ -17,6 +17,6 @@
   ;;     {:table-name :member
   ;;      :columns
   ;;      [{:column {:name :id :type :int :auto-increment true :constraints {:primary-key? true :nullable? false}}}
-  ;;       {:column {:name :login-name :type :varchar :constraints {:nullable? false}}}
+  ;;       {:column {:name :login_name :type :varchar :constraints {:nullable? false}}}
   ;;       {:column {:name :password :type :varchar :constraints {:nullable? false}}}]}}]}}
   ]}


### PR DESCRIPTION
`simple-todo-app/resources/changelog.edn` の member テーブル用のコメントアウトを外して利用すると、以下のようなエラーが出ました。

```
JdbcSQLException 列 "LOGIN" が見つかりません
Column "LOGIN" not found; SQL statement:
INSERT INTO member ( login-name, password ) VALUES ( ?, ? ) [42122-190]  org.h2.message.DbException.getJdbcSQLException (DbException.java:345)
```

どうやら `-` 以前までをカラム名にしてしまうようです。暫定的に `_` に変更したところ動作しました。
